### PR TITLE
fix(deploy): Use correct container names for production environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,8 @@ jobs:
             docker network create radio_network_alt 2>/dev/null || true
 
             # Ensure MySQL and MinIO are connected to the network
-            docker network connect radio_network_alt trendankara_mysql 2>/dev/null || true
-            docker network connect radio_network_alt trendankara_minio 2>/dev/null || true
+            docker network connect radio_network_alt radio_mysql_alt 2>/dev/null || true
+            docker network connect radio_network_alt minio 2>/dev/null || true
 
             # Run the container with all required environment variables
             docker run -d \
@@ -36,7 +36,7 @@ jobs:
               -p 3000:3000 \
               --restart always \
               -e NODE_ENV=production \
-              -e DATABASE_HOST=trendankara_mysql \
+              -e DATABASE_HOST=radio_mysql_alt \
               -e DATABASE_PORT=3306 \
               -e DATABASE_USER=root \
               -e DATABASE_PASSWORD=radiopass123 \
@@ -44,7 +44,7 @@ jobs:
               -e NEXTAUTH_URL=https://www.trendankara.com \
               -e NEXTAUTH_SECRET="${{ secrets.NEXTAUTH_SECRET }}" \
               -e AUTH_SECRET="${{ secrets.NEXTAUTH_SECRET }}" \
-              -e MINIO_ENDPOINT=trendankara_minio \
+              -e MINIO_ENDPOINT=minio \
               -e MINIO_PORT=9000 \
               -e MINIO_ACCESS_KEY=minioadmin \
               -e MINIO_SECRET_KEY=minioadmin123 \


### PR DESCRIPTION
- Change DATABASE_HOST from trendankara_mysql to radio_mysql_alt
- Change MINIO_ENDPOINT from trendankara_minio to minio
- Update network connections to use actual production container names
- Fix database connection issues in production

🤖 Generated with Claude Code